### PR TITLE
Support for compaction, closes #2

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -27,7 +27,7 @@ function makeBundler(config, assetManager, { browsers, compact, sourcemaps } = {
 		browsers = browsers.defaults;
 	}
 
-	let postCSS = makePostCSS(source, target, assetManager, sourcemaps, browsers);
+	let postCSS = makePostCSS(source, target, assetManager, sourcemaps, browsers, compact);
 
 	let previouslyIncludedFiles;
 

--- a/lib/make-postcss.js
+++ b/lib/make-postcss.js
@@ -3,14 +3,23 @@ let atImport = require("postcss-import");
 let { promisify } = require("faucet-pipeline-core/lib/util");
 let readFile = promisify(require("fs").readFile);
 
-module.exports = function(input, target, assetManager, sourcemaps, browsers) {
+module.exports = function(input, target, assetManager, sourcemaps, browsers, compact) {
 	// if(browsers && browsers.length > 0) {
 	// let filepath = path.relative(assetManager.referenceDir, input);
 	// console.error(`compiling CSS ${repr(filepath)} for ${browsers.join(", ")}`);
 
-	let processor = postcss([
+	let plugins = [
 		atImport()
-	]);
+	];
+
+	if(compact) {
+		plugins.push(
+				require("postcss-discard-comments")(),
+				require("postcss-normalize-whitespace")()
+		);
+	}
+
+	let processor = postcss(plugins);
 
 	let options = {
 		from: input,

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
 	"dependencies": {
 		"faucet-pipeline-core": "^1.0.0",
 		"postcss": "~7.0.13",
-		"postcss-import": "~12.0.1"
+		"postcss-discard-comments": "^4.0.1",
+		"postcss-import": "~12.0.1",
+		"postcss-normalize-whitespace": "~4.0.1"
 	},
 	"devDependencies": {
 		"eslint-config-fnd": "^1.6.0",

--- a/test/run
+++ b/test/run
@@ -12,6 +12,11 @@ begin "$root/test_basic"
 	assert_missing "./expected.json"
 end
 
+begin "$root/test_compact"
+	faucet --compact
+	assert_identical "./dist/bundle.css" "./expected.css"
+end
+
 begin "$root/test_error"
 	faucet || echo "Crashed successfully"
 	assert_identical "./dist/bundle.css" "./expected.css"

--- a/test/test_compact/expected.css
+++ b/test/test_compact/expected.css
@@ -1,0 +1,1 @@
+.bar{color:red}.foo{color:green}

--- a/test/test_compact/faucet.config.js
+++ b/test/test_compact/faucet.config.js
@@ -1,0 +1,15 @@
+"use strict";
+let path = require("path");
+
+module.exports = {
+	css: [{
+		source: "./src/index.css",
+		target: "./dist/bundle.css"
+	}],
+	plugins: {
+		css: {
+			plugin: path.resolve("../.."),
+			bucket: "styles"
+		}
+	}
+};

--- a/test/test_compact/src/index.css
+++ b/test/test_compact/src/index.css
@@ -1,0 +1,6 @@
+@import "./lib.css";
+
+/* a comment */
+.foo {
+	color: green;
+}

--- a/test/test_compact/src/lib.css
+++ b/test/test_compact/src/lib.css
@@ -1,0 +1,3 @@
+.bar {
+	color: red;
+}


### PR DESCRIPTION
This does not use CSSNano, but instead just chooses two parts of it that will have the biggest effect without making the CSS unreadable:

* `postcss-discard-comments`: Removes all comments
* `postcss-normalize-whitespace`: Reduces the whitespace significantly