### PR TITLE
Bugfix: Wait when writing a file

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,7 +35,7 @@ function makeBundler(config, assetManager, { browsers, compact, sourcemaps } = {
 		// If this is the first run or the changed file is one of the
 		// previously included ones, run the compiler
 		if(previouslyIncluded(filepaths, previouslyIncludedFiles)) {
-			postCSS().
+			return postCSS().
 				then(result => {
 					previouslyIncludedFiles = result.stats.includedFiles.
 						map(filepath => path.normalize(filepath));
@@ -44,14 +44,14 @@ function makeBundler(config, assetManager, { browsers, compact, sourcemaps } = {
 					if(fingerprint !== undefined) {
 						options.fingerprint = fingerprint;
 					}
-					assetManager.writeFile(target, result.css, options);
+					return assetManager.writeFile(target, result.css, options);
 				}).
 				catch(error => {
 					let options = { error };
 					if(fingerprint !== undefined) {
 						options.fingerprint = fingerprint;
 					}
-					assetManager.writeFile(target, errorOutput(error.message,
+					return assetManager.writeFile(target, errorOutput(error.message,
 							assetManager.referenceDir),
 					options);
 				});


### PR DESCRIPTION
While in exile, I experimented with CSS stuff (HSL, Variable Fonts, Layout components...) and wanted to use CSS without Sass. So I used this pipeline again, and noticed a bug: The entries are not added to the manifest in time before a markup pipeline runs. This is due to not returning the right promise. Fixed.