### PR TITLE
Update exports of module

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,12 +2,19 @@ let { abort } = require("faucet-pipeline-core/lib/util");
 let path = require("path");
 let makePostCSS = require("./make-postcss");
 
-module.exports = (config, assetManager, { browsers, compact, sourcemaps } = {}) => {
-	let bundlers = config.map(bundleConfig =>
-		makeBundler(bundleConfig, assetManager, { browsers, compact, sourcemaps }));
-
-	return filepaths => Promise.all(bundlers.map(bundle => bundle(filepaths)));
+module.exports = {
+	key: "css",
+	bucket: "styles",
+	plugin: faucetCSS
 };
+
+function faucetCSS(config, assetManager, { browsers, compact, sourcemaps } = {}) {
+	let bundlers = config.map(bundleConfig => makeBundler(bundleConfig,
+		assetManager, { browsers, compact, sourcemaps }));
+
+	return filepaths => Promise.all(bundlers.
+		map(bundler => bundler(filepaths)));
+}
 
 function makeBundler(config, assetManager, { browsers, compact, sourcemaps } = {}) {
 	let { browserslist, fingerprint } = config;


### PR DESCRIPTION
The plugins interface in faucet-pipeline-core expects a more structured object, where the plugin function is only a part, so using this plugin in its real form currently fails.